### PR TITLE
Created option to hide launched process.

### DIFF
--- a/EverythingSettings.xaml
+++ b/EverythingSettings.xaml
@@ -10,6 +10,7 @@
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition/>
+            <RowDefinition/>
             <RowDefinition Height="35"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -20,10 +21,13 @@
         <CheckBox Grid.Row="0" Grid.ColumnSpan="3" x:Name="UseLocationAsWorkingDir" Content="{DynamicResource 
                   flowlauncher_plugin_everything_use_location_as_working_dir}" 
                   Margin="10" HorizontalAlignment="Left" />
-        <Label Grid.Row="1" Margin="10" Content="{DynamicResource flowlauncher_plugin_everything_editor_path}"  
+        <CheckBox Grid.Row="1" Grid.ColumnSpan="3" x:Name="LaunchHidden" Content="{DynamicResource flowlauncher_plugin_everything_launch_hidden}" 
+                  Margin="10" HorizontalAlignment="Left" />
+
+        <Label Grid.Row="2" Margin="10" Content="{DynamicResource flowlauncher_plugin_everything_editor_path}"  
                HorizontalAlignment="Left"/>
-        <Label Grid.Row="1" Grid.Column="1" x:Name="EditorPath" Margin="10" HorizontalAlignment="Left" />
-        <Button Grid.Row="1" Grid.Column="2" x:Name="OpenEditorPath" Content="..." Margin="10" 
+        <Label Grid.Row="2" Grid.Column="1" x:Name="EditorPath" Margin="10" HorizontalAlignment="Left" />
+        <Button Grid.Row="2" Grid.Column="2" x:Name="OpenEditorPath" Content="..." Margin="10" 
                 HorizontalAlignment="Left" Click="EditorPath_Clicked"/>
         <TextBlock Grid.Row="3" Text="{DynamicResource flowlauncher_plugin_everything_customized_title}" Margin="10,0,0,0"  VerticalAlignment="Center"
                    ToolTip="{DynamicResource flowlauncher_plugin_everything_customized_tooltip}"/>

--- a/EverythingSettings.xaml.cs
+++ b/EverythingSettings.xaml.cs
@@ -28,6 +28,18 @@ namespace Flow.Launcher.Plugin.Everything
                 _settings.UseLocationAsWorkingDir = false;
             };
 
+            LaunchHidden.IsChecked = _settings.LaunchHidden;
+
+            LaunchHidden.Checked += (o, e) =>
+            {
+                _settings.LaunchHidden = true;
+            };
+
+            LaunchHidden.Unchecked += (o, e) =>
+            {
+                _settings.LaunchHidden = false;
+            };
+
             EditorPath.Content = _settings.EditorPath;
             CustomizeExplorerBox.Text = _settings.ExplorerPath;
             CustomizeArgsBox.Text = _settings.ExplorerArgs;

--- a/Languages/de.xaml
+++ b/Languages/de.xaml
@@ -14,5 +14,6 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">Suche Dateien mit Everything</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">Verwenden Suchergebnis Standort als ausführbare Arbeitsverzeichnis</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">Starten Sie versteckt</system:String>
 
 </ResourceDictionary>

--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -18,6 +18,8 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">Search on-disk files using Everything</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">Use search result's location as executable working directory</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">Launch hidden</system:String>
+    
 
     <system:String x:Key="flowlauncher_plugin_everything_customized_tooltip">You can customized the explorer for opening the containing folder by inputing the Environmental Variable or the Absolute Path of the explorer you want to use. It will be useful to use CMD to test whether the it is avaliable.</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_customized_title">Customized Explorer</system:String>

--- a/Languages/pl.xaml
+++ b/Languages/pl.xaml
@@ -12,5 +12,5 @@
     
     <system:String x:Key="flowlauncher_plugin_everything_plugin_name">Everything</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">Szukaj w plikach na dysku używając programu Everything</system:String>
-
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">Uruchomienie ukryty</system:String>    
 </ResourceDictionary>

--- a/Languages/sk.xaml
+++ b/Languages/sk.xaml
@@ -18,7 +18,8 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">Vyhľadávanie súborov cez Everything</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">Použiť cestu výsledku vyhľadávania ako pracovný priečinok spustiteľného súboru</system:String>
-
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">Launch skrytý</system:String>
+    
     <system:String x:Key="flowlauncher_plugin_everything_customized_tooltip">Na otváranie priečinka súborov môžete použiť vlastného správcu súborov vložením premennej prostredia, alebo absolútnej cesty k správcovi, ktorý chcete použiť. Na otestovanie môžete použiť príkazový riadok.</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_customized_title">Vlastný správca súborov</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_customized_args">Arg.</system:String>

--- a/Languages/tr.xaml
+++ b/Languages/tr.xaml
@@ -18,5 +18,5 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">Everything programı yardımıyla diskteki dosyalarınızı arayın.</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">Programın çalışma klasörü olarak sonuç klasörünü kullan</system:String>
-
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">Fırlatma gizli</system:String>
 </ResourceDictionary>

--- a/Languages/zh-cn.xaml
+++ b/Languages/zh-cn.xaml
@@ -18,4 +18,5 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">利用 Everything 搜索磁盘文件</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">使用应用程序的位置为可执行的工作目录</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">启动隐藏</system:String>
 </ResourceDictionary>

--- a/Languages/zh-tw.xaml
+++ b/Languages/zh-tw.xaml
@@ -14,4 +14,5 @@
     <system:String x:Key="flowlauncher_plugin_everything_plugin_description">利用 Everything 搜尋磁碟上的檔案</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_use_location_as_working_dir">使用程式所在目錄作為工作目錄</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_launch_hidden">啟動隱藏</system:String>
 </ResourceDictionary>

--- a/Main.cs
+++ b/Main.cs
@@ -20,7 +20,7 @@ namespace Flow.Launcher.Plugin.Everything
         public const string DLL = "Everything.dll";
         private readonly IEverythingApi _api = new EverythingApi();
 
-        private string installationFilePath = "C:\\Program Files\\Everything\\Everything.exe"; 
+        private string installationFilePath = "C:\\Program Files\\Everything\\Everything.exe";
 
         private PluginInitContext _context;
 
@@ -65,7 +65,7 @@ namespace Flow.Launcher.Plugin.Everything
                         IcoPath = "Images\\warning.png",
                         Action = _ =>
                         {
-                            if(SharedCommands.FilesFolders.FileExists(installationFilePath))
+                            if (SharedCommands.FilesFolders.FileExists(installationFilePath))
                                 SharedCommands.FilesFolders.OpenPath(installationFilePath);
 
                             return true;
@@ -115,9 +115,26 @@ namespace Flow.Launcher.Plugin.Everything
                         switch (searchResult.Type)
                         {
                             case ResultType.Folder:
-                                Process.Start(_settings.ExplorerPath,
-                                    _settings.ExplorerArgs.Replace(Settings.DirectoryPathPlaceHolder, $"\"{path}\""));
-                                break;
+                                if (!_settings.LaunchHidden)
+                                {
+                                    Process.Start(_settings.ExplorerPath,
+                                        _settings.ExplorerArgs.Replace(Settings.DirectoryPathPlaceHolder, $"\"{path}\""));
+                                }
+                                else
+                                {
+                                    ProcessStartInfo startInfo = new ProcessStartInfo();
+                                    //Hide the process
+                                    startInfo.UseShellExecute = false;
+                                    startInfo.RedirectStandardOutput = true;
+                                    startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                                    startInfo.CreateNoWindow = true;
+                                    //Set file and args
+                                    startInfo.FileName = _settings.ExplorerPath;
+                                    startInfo.Arguments = _settings.ExplorerArgs.Replace(Settings.DirectoryPathPlaceHolder, $"\"{path}\"");
+                                    //Start the process
+                                    Process proc = Process.Start(startInfo);
+                                }
+                                    break;
                             case ResultType.Volume:
                             case ResultType.File:
                                 Process.Start(new ProcessStartInfo
@@ -148,8 +165,6 @@ namespace Flow.Launcher.Plugin.Everything
             };
             return r;
         }
-
-
 
         private List<ContextMenu> GetDefaultContextMenu()
         {
@@ -196,7 +211,7 @@ namespace Flow.Launcher.Plugin.Everything
                                                         context.API.GetTranslation("flowlauncher_plugin_everything_installationsuccess_subtitle"), "", useMainWindowAsOwner: false);
 
                     SharedCommands.FilesFolders.OpenPath(installationFilePath);
-               
+
                 }).ContinueWith(t =>
                 {
                     Log.Exception("Main", $"Failed to install Everything service", t.Exception.InnerException, "DroplexPackage.Drop");

--- a/Settings.cs
+++ b/Settings.cs
@@ -39,6 +39,8 @@ namespace Flow.Launcher.Plugin.Everything
         public int MaxSearchCount { get; set; } = DefaultMaxSearchCount;
 
         public bool UseLocationAsWorkingDir { get; set; } = false;
+
+        public bool LaunchHidden { get; set; } = false;
     }
 
     public class ContextMenu

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Everything",
   "Description": "Search Everything",
   "Author": "qianlifeng,orzfly",
-  "Version": "1.4.1",
+  "Version": "1.4.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything",
   "IcoPath": "Images\\find.png",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Everything",
   "Description": "Search Everything",
   "Author": "qianlifeng,orzfly",
-  "Version": "1.3.0",
+  "Version": "1.4.0",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything",
   "IcoPath": "Images\\find.png",


### PR DESCRIPTION
Machine-translated languages besides English.

I use QTTabbar as a Windows Explorer replacement and by default the Everything plugin created new windows instead of new tabs.  
Working around this (with cmd or Autohotkey) flashed the console window, so I added an option to create a hidden window to the plugin.  Might be useful for others using "Customized Explorer"