### PR TITLE
add scoop installed path

### DIFF
--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -32,4 +32,5 @@
     <system:String x:Key="flowlauncher_plugin_everything_installationsuccess_subtitle">Successfully installed Everything service</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_installationfailed_subtitle">Failed to automatically install Everything service. Please manually install it from https://www.voidtools.com/Everything-1.3.4.686.x64-Setup.exe</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_run_service">Click here to start it</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_installing_select">Unable to find an Everything installation, would you like to manually select a location?{0}{0}Click no and Everything will be automatically installed for you</system:String>
 </ResourceDictionary>

--- a/Main.cs
+++ b/Main.cs
@@ -196,9 +196,25 @@ namespace Flow.Launcher.Plugin.Everything
 
         public void Init(PluginInitContext context)
         {
-            var s = Utilities.GetInstalledPath();
+            var installedLocation = Utilities.GetInstalledPath();
 
-            if (string.IsNullOrEmpty(s))
+            if (System.Windows.Forms.MessageBox.Show(
+                    string.Format(context.API.GetTranslation("flowlauncher_plugin_everything_installing_select"), Environment.NewLine),
+                            context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"), 
+                            System.Windows.Forms.MessageBoxButtons.YesNo) == System.Windows.Forms.DialogResult.Yes
+                && string.IsNullOrEmpty(installedLocation))
+            {
+                var dlg = new System.Windows.Forms.OpenFileDialog
+                {
+                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                };
+
+                var result = dlg.ShowDialog();
+                if (result == System.Windows.Forms.DialogResult.OK && string.IsNullOrEmpty(dlg.FileName))
+                    installedLocation = dlg.FileName;
+            }
+
+            if (string.IsNullOrEmpty(installedLocation))
             {
                 Task.Run(async delegate
                 {
@@ -221,7 +237,7 @@ namespace Flow.Launcher.Plugin.Everything
             }
             else
             {
-                installationFilePath = s;
+                installationFilePath = installedLocation;
             }
 
             _context = context;

--- a/Main.cs
+++ b/Main.cs
@@ -3,6 +3,7 @@ using Flow.Launcher.Infrastructure;
 using Flow.Launcher.Infrastructure.Logger;
 using Flow.Launcher.Infrastructure.Storage;
 using Flow.Launcher.Plugin.Everything.Everything;
+using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -19,8 +20,6 @@ namespace Flow.Launcher.Plugin.Everything
     {
         public const string DLL = "Everything.dll";
         private readonly IEverythingApi _api = new EverythingApi();
-
-        private string installationFilePath = "C:\\Program Files\\Everything\\Everything.exe";
 
         private PluginInitContext _context;
 
@@ -65,8 +64,8 @@ namespace Flow.Launcher.Plugin.Everything
                         IcoPath = "Images\\warning.png",
                         Action = _ =>
                         {
-                            if (SharedCommands.FilesFolders.FileExists(installationFilePath))
-                                SharedCommands.FilesFolders.OpenPath(installationFilePath);
+                            if (FilesFolders.FileExists(_settings.EverythingInstalledPath))
+                                FilesFolders.OpenPath(_settings.EverythingInstalledPath);
 
                             return true;
                         }
@@ -196,48 +195,53 @@ namespace Flow.Launcher.Plugin.Everything
 
         public void Init(PluginInitContext context)
         {
-            var installedLocation = Utilities.GetInstalledPath();
-
-            if (System.Windows.Forms.MessageBox.Show(
-                    string.Format(context.API.GetTranslation("flowlauncher_plugin_everything_installing_select"), Environment.NewLine),
-                            context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"), 
-                            System.Windows.Forms.MessageBoxButtons.YesNo) == System.Windows.Forms.DialogResult.Yes
-                && string.IsNullOrEmpty(installedLocation))
+            if (!_settings.EverythingInstalledPath.FileExists())
             {
-                var dlg = new System.Windows.Forms.OpenFileDialog
+                var installedLocation = Utilities.GetInstalledPath();
+
+                if (System.Windows.Forms.MessageBox.Show(
+                        string.Format(context.API.GetTranslation("flowlauncher_plugin_everything_installing_select"), Environment.NewLine),
+                                context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"),
+                                System.Windows.Forms.MessageBoxButtons.YesNo) == System.Windows.Forms.DialogResult.Yes
+                    && string.IsNullOrEmpty(installedLocation))
                 {
-                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
-                };
+                    var dlg = new System.Windows.Forms.OpenFileDialog
+                    {
+                        InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                    };
 
-                var result = dlg.ShowDialog();
-                if (result == System.Windows.Forms.DialogResult.OK && string.IsNullOrEmpty(dlg.FileName))
-                    installedLocation = dlg.FileName;
-            }
+                    var result = dlg.ShowDialog();
+                    if (result == System.Windows.Forms.DialogResult.OK && string.IsNullOrEmpty(dlg.FileName))
+                        installedLocation = dlg.FileName;
+                }
 
-            if (string.IsNullOrEmpty(installedLocation))
-            {
-                Task.Run(async delegate
+                if (string.IsNullOrEmpty(installedLocation))
                 {
-                    context.API.ShowMsg(context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"),
-                                                        context.API.GetTranslation("flowlauncher_plugin_everything_installing_subtitle"), "", useMainWindowAsOwner: false);
+                    Task.Run(async delegate
+                    {
+                        context.API.ShowMsg(context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"),
+                                                            context.API.GetTranslation("flowlauncher_plugin_everything_installing_subtitle"), "", useMainWindowAsOwner: false);
 
-                    await DroplexPackage.Drop(App.Everything1_3_4_686).ConfigureAwait(false);
+                        await DroplexPackage.Drop(App.Everything1_3_4_686).ConfigureAwait(false);
 
-                    context.API.ShowMsg(context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"),
-                                                        context.API.GetTranslation("flowlauncher_plugin_everything_installationsuccess_subtitle"), "", useMainWindowAsOwner: false);
+                        context.API.ShowMsg(context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"),
+                                                            context.API.GetTranslation("flowlauncher_plugin_everything_installationsuccess_subtitle"), "", useMainWindowAsOwner: false);
 
-                    SharedCommands.FilesFolders.OpenPath(installationFilePath);
+                        _settings.EverythingInstalledPath = "C:\\Program Files\\Everything\\Everything.exe";
 
-                }).ContinueWith(t =>
+                        FilesFolders.OpenPath(_settings.EverythingInstalledPath);
+
+                    }).ContinueWith(t =>
+                    {
+                        Log.Exception("Main", $"Failed to install Everything service", t.Exception.InnerException, "DroplexPackage.Drop");
+                        MessageBox.Show(context.API.GetTranslation("flowlauncher_plugin_everything_installationfailed_subtitle"),
+                            context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"));
+                    }, TaskContinuationOptions.OnlyOnFaulted);
+                }
+                else
                 {
-                    Log.Exception("Main", $"Failed to install Everything service", t.Exception.InnerException, "DroplexPackage.Drop");
-                    MessageBox.Show(context.API.GetTranslation("flowlauncher_plugin_everything_installationfailed_subtitle"),
-                        context.API.GetTranslation("flowlauncher_plugin_everything_installing_title"));
-                }, TaskContinuationOptions.OnlyOnFaulted);
-            }
-            else
-            {
-                installationFilePath = installedLocation;
+                    _settings.EverythingInstalledPath = installedLocation;
+                }
             }
 
             _context = context;

--- a/Main.cs
+++ b/Main.cs
@@ -319,9 +319,9 @@ namespace Flow.Launcher.Plugin.Everything
                         try
                         {
                             if (record.Type == ResultType.File)
-                                System.IO.File.Delete(record.FullPath);
+                                File.Delete(record.FullPath);
                             else
-                                System.IO.Directory.Delete(record.FullPath);
+                                Directory.Delete(record.FullPath);
                         }
                         catch
                         {

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
-using Flow.Launcher.Infrastructure.Storage;
 
 namespace Flow.Launcher.Plugin.Everything
 {
@@ -40,6 +38,8 @@ namespace Flow.Launcher.Plugin.Everything
         public bool UseLocationAsWorkingDir { get; set; } = false;
 
         public bool LaunchHidden { get; set; } = false;
+
+        public string EverythingInstalledPath { get; set; }
     }
 
     public class ContextMenu

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -30,6 +30,10 @@ namespace Flow.Launcher.Plugin.Everything
                 }
             }
 
+            var scoopInstalledPath = Environment.ExpandEnvironmentVariables(@"%userprofile%\scoop\apps\everything\current\Everything.exe");
+            if (File.Exists(scoopInstalledPath))
+                return scoopInstalledPath;
+
             return string.Empty;
         }
     }

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Everything",
   "Description": "Search Everything",
   "Author": "qianlifeng,orzfly",
-  "Version": "1.4.1",
+  "Version": "1.4.2",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything",
   "IcoPath": "Images\\find.png",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Everything",
   "Description": "Search Everything",
   "Author": "qianlifeng,orzfly",
-  "Version": "1.4.2",
+  "Version": "1.4.3",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything",
   "IcoPath": "Images\\find.png",


### PR DESCRIPTION
portable version of Everything installed by Scoop located at C:\Users\{username}\scoop\apps\everything\current\Everything.exe. Consider this as installed.

prompt the user to select a location or automatically install