### PR TITLE
Fix incorrect error reporting from Fast Sort check

### DIFF
--- a/Everything/EverythingAPI.cs
+++ b/Everything/EverythingAPI.cs
@@ -102,6 +102,10 @@ namespace Flow.Launcher.Plugin.Everything.Everything
         {
             var fastSortOptionEnabled = EverythingApiDllImport.Everything_IsFastSort(sortOption);
 
+            // If the Everything service is not running, then this call will incorrectly report 
+            // the state as false. This checks for errors thrown by the api and up to the caller to handle.
+            CheckAndThrowExceptionOnError();
+
             return fastSortOptionEnabled;
         }
 

--- a/Everything/EverythingAPI.cs
+++ b/Everything/EverythingAPI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -128,7 +128,7 @@ namespace Flow.Launcher.Plugin.Everything.Everything
                 CheckAndThrowExceptionOnError();
 
                 if(!fastSortOptionEnabled)
-                    throw new InvalidOperationException("The Sort Option is not Fast Sort, it may take a long time to finish the query");
+                    throw new InvalidOperationException(Main._context.API.GetTranslation("flowlauncher_plugin_everything_fastsort_error"));
 
                 EverythingApiDllImport.Everything_SetSort(sortOption);
 

--- a/Everything/EverythingAPI.cs
+++ b/Everything/EverythingAPI.cs
@@ -20,6 +20,8 @@ namespace Flow.Launcher.Plugin.Everything.Everything
         List<SearchResult> Search(string keyWord, CancellationToken token, SortOption sortOption = SortOption.NAME_ASCENDING, int offset = 0, int maxCount = 100);
 
         void Load(string sdkPath);
+
+        bool IsFastSortOption(SortOption sortOption);
     }
 
     public sealed class EverythingApi : IEverythingApi
@@ -94,6 +96,16 @@ namespace Flow.Launcher.Plugin.Everything.Everything
         }
 
         /// <summary>
+        /// Checks whether the sort option is Fast Sort.
+        /// </summary>
+        public bool IsFastSortOption(SortOption sortOption)
+        {
+            var fastSortOptionEnabled = EverythingApiDllImport.Everything_IsFastSort(sortOption);
+
+            return fastSortOptionEnabled;
+        }
+
+        /// <summary>
         /// Searches the specified key word and reset the everything API afterwards
         /// </summary>
         /// <param name="keyWord">The key word.</param>
@@ -123,12 +135,6 @@ namespace Flow.Launcher.Plugin.Everything.Everything
                 EverythingApiDllImport.Everything_SetSearchW(keyWord);
                 EverythingApiDllImport.Everything_SetOffset(offset);
                 EverythingApiDllImport.Everything_SetMax(maxCount);
-
-                var fastSortOptionEnabled = EverythingApiDllImport.Everything_IsFastSort(sortOption);
-                CheckAndThrowExceptionOnError();
-
-                if(!fastSortOptionEnabled)
-                    throw new InvalidOperationException(Main._context.API.GetTranslation("flowlauncher_plugin_everything_fastsort_error"));
 
                 EverythingApiDllImport.Everything_SetSort(sortOption);
 

--- a/Everything/EverythingAPI.cs
+++ b/Everything/EverythingAPI.cs
@@ -123,11 +123,13 @@ namespace Flow.Launcher.Plugin.Everything.Everything
                 EverythingApiDllImport.Everything_SetSearchW(keyWord);
                 EverythingApiDllImport.Everything_SetOffset(offset);
                 EverythingApiDllImport.Everything_SetMax(maxCount);
-                
-                if(!EverythingApiDllImport.Everything_IsFastSort(sortOption))
-                {
+
+                var fastSortOptionEnabled = EverythingApiDllImport.Everything_IsFastSort(sortOption);
+                CheckAndThrowExceptionOnError();
+
+                if(!fastSortOptionEnabled)
                     throw new InvalidOperationException("The Sort Option is not Fast Sort, it may take a long time to finish the query");
-                }
+
                 EverythingApiDllImport.Everything_SetSort(sortOption);
 
                 if (token.IsCancellationRequested)

--- a/EverythingSettings.xaml
+++ b/EverythingSettings.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:helper="clr-namespace:Flow.Launcher.Plugin.Everything.Helper"
-             xmlns:vm="clr-namespace:Flow.Launcher.Plugin.Everything.ViewModels"
              mc:Ignorable="d" 
              Loaded="View_Loaded"
              d:DesignHeight="300" d:DesignWidth="426.4">
@@ -70,7 +69,7 @@
         </ComboBox>
 
         <TextBlock Name ="tbFastSortWarning"  Grid.Row="4" Grid.Column="2" Margin="10 5 10 0" TextAlignment="Left"
-                   Text="{DynamicResource flowlauncher_plugin_everything_nonfastsort_warning}"
+                   Text="{Binding GetSortOptionWarningMessage}"
                    Visibility ="{Binding FastSortWarningVisibility}"
                    Foreground="Orange" TextWrapping="Wrap" />
     </Grid>

--- a/EverythingSettings.xaml
+++ b/EverythingSettings.xaml
@@ -4,9 +4,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:helper="clr-namespace:Flow.Launcher.Plugin.Everything.Helper"
+             xmlns:vm="clr-namespace:Flow.Launcher.Plugin.Everything.ViewModels"
              mc:Ignorable="d" 
              Loaded="View_Loaded"
-             DataContext="{Binding RelativeSource={RelativeSource Self}}"
              d:DesignHeight="300" d:DesignWidth="426.4">
     <Grid Margin="7,50" VerticalAlignment="Top" >
         <Grid.RowDefinitions>
@@ -51,13 +51,15 @@
         <TextBox  Grid.Row="3" Grid.Column="2" HorizontalAlignment="Right"
                   ToolTip="{DynamicResource flowlauncher_plugin_everything_customized_args_textbox}"
                   Margin="0,0,5,0" Width="80" Height="35" x:Name="CustomizeArgsBox" TextChanged="CustomizeExplorerArgs"></TextBox>
-        <TextBlock Margin="10" Text="{DynamicResource flowlauncher_plugin_everything_sort_by}" Grid.Row="4"/>
+        <TextBlock Margin="10 15 10 10" Text="{DynamicResource flowlauncher_plugin_everything_sort_by}" Grid.Row="4"/>
 
         <ComboBox Grid.Row="4" 
                   Grid.Column="1" 
-                  Width="200" 
-                  SelectedItem="{Binding _settings.SortOption}" 
-                  ItemsSource="{Binding _settings.SortOptions, Mode=OneWay}">
+                  Width="200"
+                  Margin="0 10 0 0"
+                  SelectedItem="{Binding SortOption}" 
+                  ItemsSource="{Binding GetSortOptions, Mode=OneWay}"
+                  SelectionChanged="onSelectionChange">
             <ComboBox.ItemTemplate>
                 <DataTemplate>
                     <Grid>
@@ -66,5 +68,10 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
+
+        <TextBlock Name ="tbFastSortWarning"  Grid.Row="4" Grid.Column="2" Margin="10 5 10 0" TextAlignment="Left"
+                   Text="{DynamicResource flowlauncher_plugin_everything_nonfastsort_warning}"
+                   Visibility ="{Binding FastSortWarningVisibility}"
+                   Foreground="Orange" TextWrapping="Wrap" />
     </Grid>
 </UserControl>

--- a/EverythingSettings.xaml.cs
+++ b/EverythingSettings.xaml.cs
@@ -1,80 +1,85 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
-using Flow.Launcher.Plugin.Everything.Everything;
+using Flow.Launcher.Plugin.Everything.ViewModels;
 using Microsoft.Win32;
 
 namespace Flow.Launcher.Plugin.Everything
 {
     public partial class EverythingSettings : UserControl
     {
-        public Settings _settings { get; }
+        public Settings settings { get; }
 
-        public SortOption SortOption { get; set; }
-        public SortOption[] SortOptions { get; set; }
+        private SettingsViewModel vm;
 
-        public EverythingSettings(Settings settings)
+        public EverythingSettings(Settings settings, SettingsViewModel vm)
         {
-            _settings = settings;
-            SortOption = settings.SortOption;
-            SortOptions = settings.SortOptions;
-            DataContext = this;
+            this.settings = settings;
+            this.vm = vm;
+            DataContext = vm;
             InitializeComponent();
         }
 
         private void View_Loaded(object sender, RoutedEventArgs re)
         {
-            UseLocationAsWorkingDir.IsChecked = _settings.UseLocationAsWorkingDir;
+            UseLocationAsWorkingDir.IsChecked = settings.UseLocationAsWorkingDir;
 
             UseLocationAsWorkingDir.Checked += (o, e) =>
             {
-                _settings.UseLocationAsWorkingDir = true;
+                settings.UseLocationAsWorkingDir = true;
             };
 
             UseLocationAsWorkingDir.Unchecked += (o, e) =>
             {
-                _settings.UseLocationAsWorkingDir = false;
+                settings.UseLocationAsWorkingDir = false;
             };
 
-            LaunchHidden.IsChecked = _settings.LaunchHidden;
+            LaunchHidden.IsChecked = settings.LaunchHidden;
 
             LaunchHidden.Checked += (o, e) =>
             {
-                _settings.LaunchHidden = true;
+                settings.LaunchHidden = true;
             };
 
             LaunchHidden.Unchecked += (o, e) =>
             {
-                _settings.LaunchHidden = false;
+                settings.LaunchHidden = false;
             };
 
-            EditorPath.Content = _settings.EditorPath;
-            CustomizeExplorerBox.Text = _settings.ExplorerPath;
-            CustomizeArgsBox.Text = _settings.ExplorerArgs;
+            EditorPath.Content = settings.EditorPath;
+            CustomizeExplorerBox.Text = settings.ExplorerPath;
+            CustomizeArgsBox.Text = settings.ExplorerArgs;
         }
 
         private void EditorPath_Clicked(object sender, RoutedEventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();
             openFileDialog.Filter = "Executable File(*.exe)| *.exe";
-            if (!string.IsNullOrEmpty(_settings.EditorPath))
-                openFileDialog.InitialDirectory = System.IO.Path.GetDirectoryName(_settings.EditorPath);
+            if (!string.IsNullOrEmpty(settings.EditorPath))
+                openFileDialog.InitialDirectory = System.IO.Path.GetDirectoryName(settings.EditorPath);
 
             if (openFileDialog.ShowDialog() == true)
             {
-                _settings.EditorPath = openFileDialog.FileName;
+                settings.EditorPath = openFileDialog.FileName;
             }
 
-            EditorPath.Content = _settings.EditorPath;
+            EditorPath.Content = settings.EditorPath;
         }
 
         private void CustomizeExplorer(object sender, TextChangedEventArgs e)
         {
-            _settings.ExplorerPath = CustomizeExplorerBox.Text;
+            settings.ExplorerPath = CustomizeExplorerBox.Text;
         }
 
         private void CustomizeExplorerArgs(object sender, TextChangedEventArgs e)
         {
-            _settings.ExplorerArgs = CustomizeArgsBox.Text;
+            settings.ExplorerArgs = CustomizeArgsBox.Text;
+        }
+
+        private void onSelectionChange(object sender, SelectionChangedEventArgs e)
+        {
+            // on load, tbFastSortWarning control will not have been loaded yet
+            if (tbFastSortWarning is not null)
+                tbFastSortWarning.Visibility = vm.FastSortWarningVisibility;
         }
     }
 }

--- a/EverythingSettings.xaml.cs
+++ b/EverythingSettings.xaml.cs
@@ -79,7 +79,10 @@ namespace Flow.Launcher.Plugin.Everything
         {
             // on load, tbFastSortWarning control will not have been loaded yet
             if (tbFastSortWarning is not null)
+            {
                 tbFastSortWarning.Visibility = vm.FastSortWarningVisibility;
+                tbFastSortWarning.Text = vm.GetSortOptionWarningMessage;
+            }
         }
     }
 }

--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -4,7 +4,6 @@
 
     <system:String x:Key="flowlauncher_plugin_everything_is_not_running">Everything Service is not running</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_query_error">Error while querying Everything</system:String>
-    <system:String x:Key="flowlauncher_plugin_everything_fastsort_error">Fast Sort option not enabled in Flow's Everything plugin settings, it may take a long time to finish the query</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_copied">Copied</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_canot_start">Can’t start {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_open_containing_folder">Open parent folder</system:String>
@@ -44,7 +43,7 @@
     <system:String x:Key="flowlauncher_plugin_everything_sort_by_date_run">Date Run</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_sort_by_ascending">↑</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_sort_by_descending">↓</system:String>
-
+    <system:String x:Key="flowlauncher_plugin_everything_nonfastsort_warning">Warning: This is not a Fast Sort option, searches may be slow</system:String>
 
     <system:String x:Key="flowlauncher_plugin_everything_installing_title">Everything Installation</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_installing_subtitle">Installing Everything service. Please wait...</system:String>

--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -4,6 +4,7 @@
 
     <system:String x:Key="flowlauncher_plugin_everything_is_not_running">Everything Service is not running</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_query_error">Error while querying Everything</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_fastsort_error">Fast Sort option not enabled in Flow's Everything plugin settings, it may take a long time to finish the query</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_copied">Copied</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_canot_start">Can’t start {0}</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_open_containing_folder">Open parent folder</system:String>

--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
-    <system:String x:Key="flowlauncher_plugin_everything_is_not_running">Everything Service is not running</system:String>
+    <system:String x:Key="flowlauncher_plugin_everything_is_not_running">Warning: Everything service is not running</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_query_error">Error while querying Everything</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_copied">Copied</system:String>
     <system:String x:Key="flowlauncher_plugin_everything_canot_start">Can’t start {0}</system:String>

--- a/Main.cs
+++ b/Main.cs
@@ -19,7 +19,7 @@ namespace Flow.Launcher.Plugin.Everything
         public const string DLL = "Everything.dll";
         private readonly IEverythingApi _api = new EverythingApi();
 
-        private PluginInitContext _context;
+        internal static PluginInitContext _context;
 
         private Settings _settings;
         private CancellationTokenSource _cancellationTokenSource;

--- a/Main.cs
+++ b/Main.cs
@@ -377,7 +377,7 @@ namespace Flow.Launcher.Plugin.Everything
 
         public Control CreateSettingPanel()
         {
-            return new EverythingSettings(_settings, new SettingsViewModel(_api, _settings));
+            return new EverythingSettings(_settings, new SettingsViewModel(_api, _settings, _context));
         }
     }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -1,6 +1,7 @@
 using Droplex;
 using Flow.Launcher.Plugin.Everything.Everything;
 using Flow.Launcher.Plugin.Everything.Helper;
+using Flow.Launcher.Plugin.Everything.ViewModels;
 using Flow.Launcher.Plugin.SharedCommands;
 using System;
 using System.Collections.Generic;
@@ -376,7 +377,7 @@ namespace Flow.Launcher.Plugin.Everything
 
         public Control CreateSettingPanel()
         {
-            return new EverythingSettings(_settings);
+            return new EverythingSettings(_settings, new SettingsViewModel(_api, _settings));
         }
     }
 }

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -7,16 +7,50 @@ namespace Flow.Launcher.Plugin.Everything.ViewModels
     {
         private readonly IEverythingApi api;
 
+        private readonly PluginInitContext context;
+
         private Settings settings;
-        public SettingsViewModel(IEverythingApi api, Settings settings)
+
+        public SettingsViewModel(IEverythingApi api, Settings settings, PluginInitContext context)
         {
             this.api = api;
             this.settings = settings;
+            this.context = context;
         }
 
         public Visibility FastSortWarningVisibility
         {
-            get => api.IsFastSortOption(settings.SortOption)? Visibility.Hidden : Visibility.Visible;
+            get 
+            {
+                try
+                {
+                    return api.IsFastSortOption(settings.SortOption) ? Visibility.Hidden : Visibility.Visible;
+                }
+                catch (IPCErrorException)
+                {
+                    // this error occurs if the Everything service is not running, in this instance show the warning and
+                    // update the message to let user know in the settings panel.
+                    return Visibility.Visible;
+                }
+            }
+        }
+
+        public string GetSortOptionWarningMessage
+        {
+            get
+            {
+                try
+                {
+                    // this method is used to determine if Everything service is running because as at Everything v1.4.1
+                    // the sdk does not provide a dedicated interface to determine if it is running.
+                    return api.IsFastSortOption(settings.SortOption) ? string.Empty
+                        : context.API.GetTranslation("flowlauncher_plugin_everything_nonfastsort_warning");
+                }
+                catch (IPCErrorException)
+                {
+                    return context.API.GetTranslation("flowlauncher_plugin_everything_is_not_running");
+                }
+            }
         }
 
         public SortOption[] GetSortOptions

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,33 @@
+﻿using Flow.Launcher.Plugin.Everything.Everything;
+using System.Windows;
+
+namespace Flow.Launcher.Plugin.Everything.ViewModels
+{
+    public class SettingsViewModel
+    {
+        private readonly IEverythingApi api;
+
+        private Settings settings;
+        public SettingsViewModel(IEverythingApi api, Settings settings)
+        {
+            this.api = api;
+            this.settings = settings;
+        }
+
+        public Visibility FastSortWarningVisibility
+        {
+            get => api.IsFastSortOption(settings.SortOption)? Visibility.Hidden : Visibility.Visible;
+        }
+
+        public SortOption[] GetSortOptions
+        {
+            get => settings.SortOptions;
+        }
+
+        public SortOption SortOption
+        {
+            get => settings.SortOption;
+            set => settings.SortOption = value;
+        }
+    }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Everything",
   "Description": "Search Everything",
   "Author": "qianlifeng,orzfly",
-  "Version": "1.5.3",
+  "Version": "1.5.4",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything",
   "IcoPath": "Images\\find.png",


### PR DESCRIPTION
- Fix incorrect error reporting from Fast Sort check, which reports service not running error as fast sort option not enabled.
- Updated Fast Sort option not supported message
- Switch the non-Fast Sort search restriction to plugin setting warning
- Show Everything service not running in settings
![image](https://user-images.githubusercontent.com/26427004/134336600-e1c76826-2c94-4f92-89b3-d08f9fe844fd.png)
![image](https://user-images.githubusercontent.com/26427004/134514667-c6b1d5b2-252c-4ab0-898c-69a4e1cc6b84.png)

close https://github.com/Flow-Launcher/Flow.Launcher.Plugin.Everything/issues/34